### PR TITLE
Disable setloading, move write of chart object

### DIFF
--- a/apex.custom.chart.js
+++ b/apex.custom.chart.js
@@ -138,7 +138,9 @@ if ( apex.custom === undefined ) {
         // set up the refresh function
         var _refresh = function(pDefaults){
           var lDataPromise;
-          lChart.setLoading("");
+          
+           // set loading caused exception errors.
+          //lChart.setLoading("");
           
           apex.debug("refresh chart");
           lTarget$.trigger("apexbeforerefresh");
@@ -171,6 +173,9 @@ if ( apex.custom === undefined ) {
           });
         };
         
+        // new location is before data is called for
+        lChart.write( lTarget$[0] );
+
         // retrieve the defaults. Note that the defaultsLocation param could be a url etc, it doesn't have to be a file location
         // TODO: make this a function callback
         var lDefaultsPromise;
@@ -179,7 +184,7 @@ if ( apex.custom === undefined ) {
         } else if ( $.type(pOptions.ajax.defaults) === "object" && $.type(pOptions.ajax.defaults) === "object" ) {
           lDefaultsPromise = $.ajax(pOptions.ajax.defaults);
         };
-        
+
         lDefaultsPromise.done(function(pDefaults){
           lDefaults = pDefaults;
           apex.debug("defaults fetched: ");
@@ -188,7 +193,8 @@ if ( apex.custom === undefined ) {
           lTarget$.on("apexrefresh", function(){ _refresh(lDefaults); }).trigger("apexrefresh");
         });
         
-        lChart.write( lTarget$[0] );
+        // changed location above de faults promise.
+        //lChart.write( lTarget$[0] );
         
         gAllCharts.push({"id":lTarget$.attr("id"),"chartObject":lChart});
         


### PR DESCRIPTION
Disabled the set loading function of any chart. This gave excpetion errors by AnyChart.

The write function to show the chart object was moved before the callback to fetch the defaults data.
